### PR TITLE
UUID reading from metadata.json in Makefile fixed for python2 and python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #=============================================================================
-UUID=$(shell cat src/metadata.json | python -c "import json,sys;obj=json.load(sys.stdin);print obj['uuid'];")
+UUID=$(shell cat src/metadata.json | python -c "import json,sys;obj=json.load(sys.stdin);print(obj['uuid']);")
 SRCDIR=src
 BUILDDIR=build
 FILES=metadata.json *.js stylesheet.css schemas icons


### PR DESCRIPTION
python2 supports "print(…)" as well as python3 does. Python3 does not support "print …"