### PR TITLE
More robust activation of System Monitor

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -50,7 +50,10 @@ class SysPeekGSBtn extends PanelMenu.Button
         this.menu.addAction( TEXT_SYSMON, event => {
             let appSystem = Shell.AppSystem.get_default();
             let app = appSystem.lookup_app('gnome-system-monitor.desktop');
-            app.activate_full(-1, event.get_time());
+            app = app || appSystem.lookup_app('org.gnome.SystemMonitor.desktop');
+            if ( app !== null ) {
+                app.activate_full(-1, event.get_time());
+            }
         });
 
         this._micpu = new PopupMenu.PopupMenuItem( TEXT_CPU );

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "SysPeek-GS",
-    "version": 14,
+    "version": 15,
     "description": "Minimalistic CPU load monitor widget inspired by SysPeek indicator",
     "url": "https://github.com/eugene-rom/syspeek-gs",
     "uuid": "syspeek-gs@gs.eros2.info",


### PR DESCRIPTION
Tries to find System Monitor using `org.gnome.SystemMonitor.desktop` if `gnome-system-monitor.desktop` is not found, and avoids showing an error if the app name is null. It should work with System Monitor installed as Flatpak as well.